### PR TITLE
feat: add Brewfile template to generate from packages.yaml

### DIFF
--- a/dot_Brewfile.tmpl
+++ b/dot_Brewfile.tmpl
@@ -1,0 +1,12 @@
+{{- if eq .chezmoi.os "darwin" -}}
+{{- with .packages.darwin }}
+
+{{- range .brews }}
+brew "{{ . }}"
+{{- end }}
+
+{{- range .casks }}
+cask "{{ . }}"
+{{- end }}
+{{- end }}
+{{- end -}}


### PR DESCRIPTION
- Add dot_Brewfile.tmpl to automatically generate Brewfile from .chezmoidata/packages.yaml
- Exclude docker cask to avoid sudo permission issues during installation
- Fix 'Brewfile not found' error in brew setup script
- Enables automated package management through chezmoi