### PR TITLE
Switch symlinks to hard links and update prompt paths

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -16,7 +16,6 @@ packages:
       - 'zsh-git-prompt'
       - 'zsh-syntax-highlighting'
       - 'awscli'
-      - '1password-cli'
       - 'mcp-proxy'
       - 'codex'
     casks:
@@ -35,3 +34,4 @@ packages:
       - 'warp'
       - '1password'
       - 'chatgpt'
+      - '1password-cli'

--- a/.chezmoiscripts/run_once_setup_ai_agents.sh
+++ b/.chezmoiscripts/run_once_setup_ai_agents.sh
@@ -11,44 +11,44 @@ CLAUDE_COMMANDS_DIR="$HOME/.claude/commands"
 mkdir -p "$CODEX_PROMPTS_DIR"
 mkdir -p "$CLAUDE_COMMANDS_DIR"
 
-# Create symlinks for shared prompts in codex (flattened structure, excluding rules.md)
+# Create hard links for shared prompts in codex (flattened structure, excluding rules.md)
 find "$SHARED_PROMPTS_DIR/prompts" -name "*.md" -type f | while read -r prompt_file; do
     filename=$(basename "$prompt_file")
-    symlink_path="$CODEX_PROMPTS_DIR/$filename"
+    hardlink_path="$CODEX_PROMPTS_DIR/$filename"
     
-    if [ ! -e "$symlink_path" ]; then
-        ln -s "$prompt_file" "$symlink_path"
-        echo "Created symlink: $symlink_path -> $prompt_file"
+    if [ ! -e "$hardlink_path" ]; then
+        ln "$prompt_file" "$hardlink_path"
+        echo "Created hard link: $hardlink_path -> $prompt_file"
     fi
 done
 
-# Create symlinks for shared prompts in claude (flattened structure, excluding rules.md)
+# Create hard links for shared prompts in claude (flattened structure, excluding rules.md)
 find "$SHARED_PROMPTS_DIR/prompts" -name "*.md" -type f | while read -r prompt_file; do
     filename=$(basename "$prompt_file")
-    symlink_path="$CLAUDE_COMMANDS_DIR/$filename"
+    hardlink_path="$CLAUDE_COMMANDS_DIR/$filename"
     
-    if [ ! -e "$symlink_path" ]; then
-        ln -s "$prompt_file" "$symlink_path"
-        echo "Created symlink: $symlink_path -> $prompt_file"
+    if [ ! -e "$hardlink_path" ]; then
+        ln "$prompt_file" "$hardlink_path"
+        echo "Created hard link: $hardlink_path -> $prompt_file"
     fi
 done
 
-# Create symlink for rules.md in codex (as AGENTS.md)
+# Create hard link for rules.md in codex (as AGENTS.md)
 RULES_FILE="$SHARED_PROMPTS_DIR/rules.md"
 if [ -f "$RULES_FILE" ]; then
     CODEX_RULES_LINK="$HOME/.codex/AGENTS.md"
     if [ ! -e "$CODEX_RULES_LINK" ]; then
-        ln -s "$RULES_FILE" "$CODEX_RULES_LINK"
-        echo "Created symlink: $CODEX_RULES_LINK -> $RULES_FILE"
+        ln "$RULES_FILE" "$CODEX_RULES_LINK"
+        echo "Created hard link: $CODEX_RULES_LINK -> $RULES_FILE"
     fi
 fi
 
-# Create symlink for rules.md in claude (as CLAUDE.md)
+# Create hard link for rules.md in claude (as CLAUDE.md)
 if [ -f "$RULES_FILE" ]; then
     CLAUDE_RULES_LINK="$HOME/.claude/CLAUDE.md"
     if [ ! -e "$CLAUDE_RULES_LINK" ]; then
-        ln -s "$RULES_FILE" "$CLAUDE_RULES_LINK"
-        echo "Created symlink: $CLAUDE_RULES_LINK -> $RULES_FILE"
+        ln "$RULES_FILE" "$CLAUDE_RULES_LINK"
+        echo "Created hard link: $CLAUDE_RULES_LINK -> $RULES_FILE"
     fi
 fi
 

--- a/dot_ai_agents/prompts/commit-and-create-pr.md
+++ b/dot_ai_agents/prompts/commit-and-create-pr.md
@@ -5,6 +5,6 @@ description: コミットからプルリクエスト作成まで一括実行
 
 以下3つのタスクを上から順番に独立して実行してください。
 
-1. @~/.claude/commands/commit-push.md を実行
-2. @~/.claude/commands/create-pr.md を実行
+1. @~/.ai_agents/prompts/commit-push.md を実行
+2. @~/.ai_agents/prompts/create-pr.md を実行
 3. gh pr view --webを実行

--- a/dot_ai_agents/prompts/create-pr.md
+++ b/dot_ai_agents/prompts/create-pr.md
@@ -4,7 +4,7 @@ description: プルリクエストを作成する
 # Create PR
 
 プルリクエストを作成してください。
-プルリクエストの本文は `@~/.claude/commands/create-pr-body.md` を実行して作成してください。
+プルリクエストの本文は `@~/.ai_agents/prompts/create-pr-body.md` を実行して作成してください。
 
 ```bash
 gh pr create --title "プルリクエストのタイトル" --body "プルリクエストの本文"

--- a/dot_claude/commands/.gitkeep
+++ b/dot_claude/commands/.gitkeep
@@ -1,2 +1,0 @@
-# This file exists to ensure the commands directory is tracked by Git
-# The directory will be populated with symlinks by the setup script 

--- a/dot_codex/prompts/.gitkeep
+++ b/dot_codex/prompts/.gitkeep
@@ -1,2 +1,0 @@
-# This file exists to ensure the commands directory is tracked by Git
-# The directory will be populated with symlinks by the setup script 


### PR DESCRIPTION
## Why

- シンボリックリンクは環境やツールによって挙動差や解決失敗が起こるため、確実に内容を参照できるハードリンクに統一して安定性を高めるため。
- AIエージェント関連の参照先を `~/.ai_agents` に統一し、利用場所と実体の不一致を解消するため。
- 不要となった `.gitkeep` を削除してリポジトリ構成を簡潔に保つため。

## What

- セットアップスクリプトで作成するリンクをシンボリックリンクからハードリンクに変更。
- プロンプト参照パスを `~/.ai_agents` 系に更新。
- 役目を終えた `.gitkeep` を削除。
