### PR TITLE
Add thebrowsercompany dia cask

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -35,3 +35,4 @@ packages:
       - '1password'
       - 'chatgpt'
       - '1password-cli'
+      - 'thebrowsercompany-dia'


### PR DESCRIPTION
## Why

DiaをHomebrewのcask経由で管理するため。

## What

-  のcaskリストに  を追加