### PR TITLE
chore(config): update Claude and MCP settings

### DIFF
--- a/dot_claude/dot_mcp.json
+++ b/dot_claude/dot_mcp.json
@@ -18,10 +18,12 @@
         "streamablehttp",
         "-H",
         "Authorization",
-        "Bearer {$GITHUB_TOKEN}",
+        "Bearer ${GITHUB_TOKEN}",
         "https://api.githubcopilot.com/mcp/"
       ],
-      "env": {}
+      "env": {
+        "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+      }
     },
     "serena": {
       "type": "stdio",

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -2,6 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "includeCoAuthoredBy": false,
   "permissions": {
+    "defaultMode": "acceptEdits",
     "allow": [
       "List(*)",
       "Fetch(*)",
@@ -80,6 +81,7 @@
       "mcp__devinwiki__ask_question"
     ],
     "deny": [
+      "Fetch(https://api.github.com/*)",
       "Bash(rm:*)",
       "Bash(rm -rf:*)",
       "Bash(git reset:*)",
@@ -123,6 +125,8 @@
   },
   "alwaysThinkingEnabled": true,
   "enabledPlugins": {
-    "example-skills@anthropic-agent-skills": true
+    "example-skills@anthropic-agent-skills": true,
+    "context7@claude-plugins-official": true,
+    "code-review@claude-plugins-official": true
   }
 }

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -3,6 +3,10 @@
   "includeCoAuthoredBy": false,
   "permissions": {
     "defaultMode": "acceptEdits",
+    "deniedWebFetchPatterns": [
+      "Fetch(https://github.com/*)",
+      "Fetch(https://api.github.com/*)"
+    ],
     "allow": [
       "List(*)",
       "Fetch(*)",
@@ -56,6 +60,7 @@
       "Bash(gh issue edit:*)",
       "Bash(gh issue view:*)",
       "Bash(gh issue list:*)",
+      "Bash(gh api:*)",
       "Bash(git checkout:*)",
       "Bash(git add:*)",
       "Bash(git commit:*)",
@@ -81,7 +86,6 @@
       "mcp__devinwiki__ask_question"
     ],
     "deny": [
-      "Fetch(https://api.github.com/*)",
       "Bash(rm:*)",
       "Bash(rm -rf:*)",
       "Bash(git reset:*)",


### PR DESCRIPTION
## Why

- Claude設定とMCP設定の改善が必要
- セキュリティとプラグインの有効化のため

## What

- MCPのGitHub Copilotトークン変数の構文を修正（`{$GITHUB_TOKEN}` → `${GITHUB_TOKEN}`）
- Claude設定に`defaultMode: acceptEdits`を追加
- セキュリティのためGitHub APIへのFetchリクエストを拒否
- context7とcode-reviewプラグインを有効化