### PR TITLE
build(packages): add webcatalog to package list

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -36,3 +36,4 @@ packages:
       - 'chatgpt'
       - '1password-cli'
       - 'thebrowsercompany-dia'
+      - 'webcatalog'


### PR DESCRIPTION
## Why

開発環境のセットアップを効率化するため、Webアプリケーションをネイティブアプリのように管理できるWebCatalogをパッケージリストに追加します。

## What

- `.chezmoidata/packages.yaml`に`webcatalog`パッケージを追加
- chezmoiで管理されるパッケージリストに含めることで、環境構築時に自動的にインストールされるようになります