### PR TITLE
feat(zshrc): add clauded alias and git gtr alias

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -6,6 +6,7 @@ alias ls="ls -lah"
 alias che="chezmoi"
 alias python="python3"
 alias gwr='git gtr'
+alias clauded='claude --dangerously-skip-permissions'
 
 # -------------------
 # Zsh Prompt Settings


### PR DESCRIPTION
## Why

`claude --dangerously-skip-permissions` は開発中に頻繁に使用するコマンドで、毎回長いフラグを打つのが煩雑だった。また、`git gtr` も短いエイリアスで呼び出せるようにする。

## What

- `clauded` エイリアスを追加し、`claude --dangerously-skip-permissions` の短縮形とする
- `gwr` エイリアスを追加し、`git gtr` の短縮形とする
- 以前の `claude` エイリアス（`NODENV_VERSION=20.9.0 claude`）を削除する