### PR TITLE
Add codex package and adjust claude settings

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -37,3 +37,4 @@ packages:
       - '1password-cli'
       - 'thebrowsercompany-dia'
       - 'webcatalog'
+      - 'codex'

--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -37,4 +37,4 @@ packages:
       - '1password-cli'
       - 'thebrowsercompany-dia'
       - 'webcatalog'
-      - 'codex'
+      - 'codex-app'

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -86,8 +86,6 @@
       "mcp__devinwiki__ask_question"
     ],
     "deny": [
-      "Bash(rm:*)",
-      "Bash(rm -rf:*)",
       "Bash(git reset:*)",
       "Bash(git rebase:*)",
       "Bash(sudo:*)",


### PR DESCRIPTION
## Why
Codexの利用に必要な環境を整え、Claude設定の制約を見直すため。

## What
- パッケージ一覧にcodexを追加
- Claude設定のdenyからrm系ルールを削除