### PR TITLE
chore(claude): add statusline command and update settings/mcp config

### DIFF
--- a/dot_claude/dot_mcp.json
+++ b/dot_claude/dot_mcp.json
@@ -24,20 +24,6 @@
       "env": {
         "GITHUB_TOKEN": "${GITHUB_TOKEN}"
       }
-    },
-    "serena": {
-      "type": "stdio",
-      "command": "uvx",
-      "args": [
-        "--from",
-        "git+https://github.com/oraios/serena",
-        "serena-mcp-server",
-        "--context",
-        "ide-assistant",
-        "--enable-web-dashboard",
-        "False"
-      ],
-      "env": {}
     }
   }
 }

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -1,12 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "includeCoAuthoredBy": false,
+  "includeCoAuthoredBy": true,
   "permissions": {
-    "defaultMode": "acceptEdits",
-    "deniedWebFetchPatterns": [
-      "Fetch(https://github.com/*)",
-      "Fetch(https://api.github.com/*)"
-    ],
     "allow": [
       "List(*)",
       "Fetch(*)",
@@ -99,6 +94,11 @@
       "Read(~/.npmrc)",
       "Read(~/.pypirc)",
       "Read(~/.bundle/config)"
+    ],
+    "defaultMode": "acceptEdits",
+    "deniedWebFetchPatterns": [
+      "Fetch(https://github.com/*)",
+      "Fetch(https://api.github.com/*)"
     ]
   },
   "hooks": {
@@ -125,10 +125,16 @@
       }
     ]
   },
-  "alwaysThinkingEnabled": true,
   "enabledPlugins": {
     "example-skills@anthropic-agent-skills": true,
     "context7@claude-plugins-official": true,
-    "code-review@claude-plugins-official": true
+    "code-review@claude-plugins-official": true,
+    "ruby-lsp@claude-plugins-official": true
+  },
+  "alwaysThinkingEnabled": true,
+  "skipDangerousModePermissionPrompt": true,
+  "statusLine": {
+    "type": "command",
+    "command": "bash ~/.claude/statusline-command.sh"
   }
 }

--- a/dot_claude/statusline-command.sh
+++ b/dot_claude/statusline-command.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+input=$(cat)
+cwd=$(echo "$input" | jq -r '.workspace.current_dir // .cwd')
+model=$(echo "$input" | jq -r '.model.display_name // empty')
+used=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+
+# ユーザー名とホスト名
+user=$(whoami)
+host=$(hostname -s)
+
+# ディレクトリ表示（ホームディレクトリを ~ に短縮）
+home="$HOME"
+display_dir="${cwd/#$home/~}"
+
+# git ブランチ情報（オプショナル）
+git_info=""
+if git -C "$cwd" rev-parse --is-inside-work-tree --no-optional-locks 2>/dev/null | grep -q true; then
+  branch=$(git -C "$cwd" symbolic-ref --short HEAD 2>/dev/null || git -C "$cwd" rev-parse --short HEAD 2>/dev/null)
+  if [ -n "$branch" ]; then
+    git_info=" ($branch)"
+  fi
+fi
+
+# コンテキスト使用率
+context_info=""
+if [ -n "$used" ]; then
+  context_info=" [ctx: ${used}%]"
+fi
+
+# モデル情報
+model_info=""
+if [ -n "$model" ]; then
+  model_info=" | $model"
+fi
+
+printf "\033[32m%s\033[0m@\033[36m%s\033[0m:\033[34m%s\033[0m\033[33m%s\033[0m\033[35m%s\033[0m%s" \
+  "$user" "$host" "$display_dir" "$git_info" "$context_info" "$model_info"

--- a/dot_codex/private_config.toml
+++ b/dot_codex/private_config.toml
@@ -10,6 +10,7 @@ approval_policy = "never"
 sandbox_mode = "danger-full-access"
 
 notify = ["bash", "-lc", "afplay /System/Library/Sounds/Ping.aiff"]
+model = "gpt-5.4
 
 [sandbox_workspace_write]
 # Allow network access in workspace-write mode
@@ -19,14 +20,6 @@ network_access = true
 web_search_request = true
 
 # MCP Servers configuration
-[mcp_servers.serena]
-command = "uvx"
-args = [
-  "--from", "git+https://github.com/oraios/serena",
-  "serena", "start-mcp-server",
-  "--context", "codex",
-  "--enable-web-dashboard", "False"
-]
 
 [mcp_servers.github]
 url = "https://api.githubcopilot.com/mcp/"


### PR DESCRIPTION
## Why

Claude CodeのステータスラインをカスタマイズしてUXを改善するため。また、使用しなくなったserena MCPサーバーの設定を整理するため。

## What

- `statusline-command.sh` を新規追加: ユーザー名・ホスト名・カレントディレクトリ・gitブランチ・コンテキスト使用率・モデル名をカラーで表示するステータスラインスクリプト
- `settings.json` を更新:
  - `statusLine` 設定を追加して `statusline-command.sh` を利用するよう設定
  - `ruby-lsp` プラグインを有効化
  - `skipDangerousModePermissionPrompt: true` を追加
  - `includeCoAuthoredBy: true` に変更
  - `alwaysThinkingEnabled` の位置を `enabledPlugins` の後に移動
- `dot_mcp.json` を更新: serena MCPサーバーの設定を削除
- `private_config.toml` を更新: serena MCPサーバーの設定を削除、modelを追加