### PR TITLE
[codex] fix codex config

### DIFF
--- a/dot_codex/private_config.toml
+++ b/dot_codex/private_config.toml
@@ -10,16 +10,11 @@ approval_policy = "never"
 sandbox_mode = "danger-full-access"
 
 notify = ["bash", "-lc", "afplay /System/Library/Sounds/Ping.aiff"]
-model = "gpt-5.4
+model = "gpt-5.4"
 
 [sandbox_workspace_write]
 # Allow network access in workspace-write mode
 network_access = true
-
-[features]
-web_search_request = true
-
-# MCP Servers configuration
 
 [mcp_servers.github]
 url = "https://api.githubcopilot.com/mcp/"
@@ -32,3 +27,9 @@ args = [
   "-y",
   "@upstash/context7-mcp"
 ]
+
+[plugins."github@openai-curated"]
+enabled = true
+
+[plugins."google-drive@openai-curated"]
+enabled = true


### PR DESCRIPTION
## What changed
- fixed the broken `model` string in `dot_codex/private_config.toml`
- removed the obsolete `[features]` section
- enabled the curated GitHub and Google Drive plugins

## Why
- the config contained invalid TOML and could not be parsed correctly
- plugin enablement is now declared explicitly in the current config shape

## Impact
- Codex can load the config successfully
- GitHub and Google Drive plugin features are available from this setup

## Validation
- `python3 -c "import tomllib, pathlib; tomllib.loads(pathlib.Path('dot_codex/private_config.toml').read_text())"`
