### PR TITLE
[codex] Add discord package

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -38,3 +38,4 @@ packages:
       - 'thebrowsercompany-dia'
       - 'webcatalog'
       - 'codex-app'
+      - 'discord'


### PR DESCRIPTION
## What changed
- Added `discord` to the Homebrew cask package list in `.chezmoidata/packages.yaml`

## Why
- So Discord is included in the managed package set for this dotfiles environment

## Impact
- `chezmoi`-managed package provisioning will now install Discord alongside the existing GUI apps

## Validation
- Parsed `.chezmoidata/packages.yaml` with Ruby YAML loader successfully
- Confirmed the change is isolated to a single package entry addition