### PR TITLE
fix(zshrc): Ctrl+T ブランチ選択でworktreeに移動できないバグを修正

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -51,7 +51,7 @@ fbr() {
   local branches branch worktree_path
   branches=$(git branch -vv) || return
   branch=$(echo "$branches" | fzf +m) || return
-  branch=$(echo "$branch" | awk '{print $1}' | sed "s/.* //")
+  branch=$(echo "$branch" | awk '{if ($1 == "*" || $1 == "+") print $2; else print $1}')
   # worktreeで既にチェックアウト済みの場合はそのディレクトリへcd
   worktree_path=$(git worktree list --porcelain | awk -v b="refs/heads/$branch" '/^worktree/{w=$2} $0 == "branch " b {print w}')
   if [ -n "$worktree_path" ]; then

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -48,10 +48,17 @@ fi
 # checkout git branch
 # -------------------
 fbr() {
-  local branches branch
-  branches=$(git branch -vv) &&
-  branch=$(echo "$branches" | fzf +m) &&
-  git checkout $(echo "$branch" | awk '{print $1}' | sed "s/.* //")
+  local branches branch worktree_path
+  branches=$(git branch -vv) || return
+  branch=$(echo "$branches" | fzf +m) || return
+  branch=$(echo "$branch" | awk '{print $1}' | sed "s/.* //")
+  # worktreeで既にチェックアウト済みの場合はそのディレクトリへcd
+  worktree_path=$(git worktree list --porcelain | awk -v b="refs/heads/$branch" '/^worktree/{w=$2} $0 == "branch " b {print w}')
+  if [ -n "$worktree_path" ]; then
+    cd "$worktree_path"
+  else
+    git checkout "$branch"
+  fi
 }
 
 # -------------------


### PR DESCRIPTION
## 変更内容

`fbr` 関数（Ctrl+Tで起動するブランチ選択）がworktree環境で動作しないバグを修正。

### 問題

`git checkout <branch>` はそのブランチが別のworktreeで既にチェックアウト済みの場合にエラーになる。

### 修正

`git worktree list --porcelain` で対象ブランチのworktreeパスを確認し、  
存在すれば `cd` で移動、存在しなければ従来通り `git checkout` を実行するよう変更。

## 動作確認

- worktreeで別ブランチを選択 → そのworktreeディレクトリへ移動
- 通常リポジトリでブランチ選択 → 従来通り `git checkout`