### PR TITLE
feat(claude): Google Workspaceリソースはgwsコマンドを使う指示を追加

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -1,0 +1,4 @@
+
+Always respond and explain in Japanese.
+For GitHub operations, use the `gh` command or MCP.
+When accessing Google Workspace resources (Google Spreadsheet/gss, Docs, Drive, Gmail, Calendar, Slides, etc.), use the `gws` command (Google Workspace CLI). Example: `gws sheets spreadsheets get --params '{"spreadsheetId": "..."}'`. Run `gws --help` or `gws schema <service.resource.method>` to discover available services and parameters.


### PR DESCRIPTION
## 変更内容
- `~/.claude/CLAUDE.md`(Claudeのグローバル指示)に、Google Workspaceリソースを参照する際は `gws` コマンド(Google Workspace CLI)を使う指示を追記
- あわせて、これまでchezmoi未管理だった `~/.claude/CLAUDE.md` をchezmoi管理下(`dot_claude/CLAUDE.md`)に追加

## 理由・目的
- gss(Googleスプレッドシート)などGoogle Workspaceのリソースを見るとき、Claudeに `gws` コマンドを使ってほしいため
- 具体例とヘルプ/スキーマ確認方法も併記し、サービスやパラメータを自己発見できるようにした

## 動作確認
- `chezmoi diff` / `chezmoi apply --force ~/.claude/CLAUDE.md` で意図通り反映されることを確認済み