### PR TITLE
Claude Code のデフォルト権限モードを auto にする

### DIFF
--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -98,7 +98,7 @@
       "Read(~/.pypirc)",
       "Read(~/.bundle/config)"
     ],
-    "defaultMode": "acceptEdits"
+    "defaultMode": "auto"
   },
   "hooks": {
     "Notification": [


### PR DESCRIPTION
## Why

Claude Code をグローバルで `acceptEdits` モードで使っていたが、編集以外の操作で都度確認が入っていた。Opus 4.6 以降で使える `auto` モードは安全性チェック(分類器)付きですべての操作を自動実行するため、確認の手間を減らしつつ安全性を保てる。

## What

`~/.claude/settings.json`(chezmoi の `dot_claude/settings.json`)の `permissions.defaultMode` を `acceptEdits` から `auto` に変更した。

`auto` はセキュリティ上の理由でリポジトリ設定では無視されるため、グローバル設定に置く必要がある。今回の変更先はグローバル設定なので問題なく有効になる。