### PR TITLE
Claude Code設定でgit force pushをdenyに追加

### DIFF
--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -86,6 +86,9 @@
     "deny": [
       "Bash(git reset:*)",
       "Bash(git rebase:*)",
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Bash(git push --force-with-lease:*)",
       "Bash(sudo:*)",
       "Read(.env.*)",
       "Read(~/.aws/*)",


### PR DESCRIPTION
## 変更内容
`dot_claude/settings.json` の `permissions.deny` に git の force push を3パターン追加しました。

- `Bash(git push --force:*)`
- `Bash(git push -f:*)`
- `Bash(git push --force-with-lease:*)`

## 目的
Claude Code から誤って force push が実行され、リモートの履歴が破壊されるのを防ぐため。

## 動作確認
`chezmoi diff` でソースと適用先に差分がないことを確認済み。