### PR TITLE
git cleanup-branches コマンドを追加する

### DIFF
--- a/dot_local/bin/executable_git-cleanup-branches
+++ b/dot_local/bin/executable_git-cleanup-branches
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# git cleanup-branches [-w|--worktrees]
+#
+# カレントブランチ以外のローカルブランチを全部削除する。
+# -w / --worktrees を付けるとカレント以外の worktree も先に全部削除し、
+# それらに紐づいていたブランチも削除できるようにする。
+#
+# worktree でチェックアウト中のブランチは削除できないため、-w なしの場合は
+# git 自身がそのブランチをスキップしてエラーメッセージを出す（他のブランチの
+# 削除は継続する）。
+set -u
+
+del_wt=0
+case "${1:-}" in
+  -w | --worktrees) del_wt=1 ;;
+  "") ;;
+  *)
+    echo "unknown option: $1 (use -w/--worktrees to also remove worktrees)" >&2
+    exit 1
+    ;;
+esac
+
+current=$(git symbolic-ref --quiet --short HEAD) || {
+  echo "detached HEAD のため中止する" >&2
+  exit 1
+}
+
+if [ "$del_wt" -eq 1 ]; then
+  main_wt=$(git rev-parse --show-toplevel)
+  git worktree list --porcelain | sed -n 's/^worktree //p' | while IFS= read -r wt; do
+    [ "$wt" = "$main_wt" ] && continue
+    git worktree remove --force "$wt"
+  done
+  git worktree prune
+fi
+
+git for-each-ref --format='%(refname:short)' refs/heads/ | grep -vxF "$current" | while IFS= read -r branch; do
+  git branch -D "$branch"
+done
+
+exit 0


### PR DESCRIPTION
## Why

worktree とローカルブランチが溜まったときに、カレントブランチだけ残して一括で掃除したい。手作業で `git branch -D` を並べたり worktree を1つずつ消すのは面倒なので、専用コマンドを用意する。

## What

`~/.local/bin/git-cleanup-branches` を追加する。`~/.local/bin` は PATH に入っており、git は PATH 上の `git-<name>` を自動でサブコマンドとして認識するため、`git cleanup-branches` として呼べる。

- `git cleanup-branches`: カレントブランチ以外のローカルブランチを全部削除する。worktree でチェックアウト中のブランチは git が削除を拒否してスキップする（他のブランチ削除は継続）。
- `git cleanup-branches -w` / `--worktrees`: カレント以外の worktree を先に全部削除してから、紐づいていたブランチも含めて削除する。

分岐が多くロジックも長いため、gitconfig の1行エイリアスに押し込むとエスケープが煩雑で保守しづらくなる。読みやすさと保守性を優先して外部スクリプトにした。

### 動作確認

ブランチ3本 + worktree 2本のテストリポジトリで以下を確認した。

- デフォルト: worktree 未使用のブランチのみ削除、worktree 使用中ブランチは保護（exit 0）
- `-w`: カレント以外の worktree を削除し、全ブランチを削除（exit 0）
- 他ブランチが無い場合・不明オプション指定時のハンドリング