### PR TITLE
[codex] Add Google Cloud CLI packages

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -18,6 +18,7 @@ packages:
       - 'awscli'
       - 'mcp-proxy'
       - 'codex'
+      - 'googleworkspace-cli'
     casks:
       - 'cursor'
       - 'deepl'
@@ -39,3 +40,4 @@ packages:
       - 'codex-app'
       - 'discord'
       - 'superwhisper'
+      - 'gcloud-cli'


### PR DESCRIPTION
## Summary

Adds Google Workspace CLI and Google Cloud CLI to the chezmoi package data so the generated Brewfile installs both tools.

## Impact

Running chezmoi apply or using the generated Brewfile will include:

- `googleworkspace-cli` as a Homebrew formula
- `gcloud-cli` as a Homebrew cask

## Validation

- `chezmoi diff --no-pager`
- Confirmed staged diff contains only `.chezmoidata/packages.yaml` with two package additions.