### PR TITLE
feat: main/master ブランチへの git push を弾くユーザーレベルフックを追加

### DIFF
--- a/dot_claude/hooks/block-push-to-main.sh
+++ b/dot_claude/hooks/block-push-to-main.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# PreToolUse フック: 現在のブランチが main のときの git push を弾く。
+# `git push` 系コマンドのときだけ呼ばれる想定（settings.json の "if" でフィルタ）。
+set -euo pipefail
+
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+if [ "${ALLOW_PUSH_TO_MAIN:-}" = "1" ]; then
+  exit 0
+fi
+
+if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+  cat <<'JSON'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "main / master ブランチへの直接pushは禁止です。バイパスするには環境変数 ALLOW_PUSH_TO_MAIN=1 を設定してClaudeを起動してください。"
+  }
+}
+JSON
+fi

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -130,6 +130,18 @@
     "defaultMode": "auto"
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git push:*)",
+            "command": "~/.claude/hooks/block-push-to-main.sh"
+          }
+        ]
+      }
+    ],
     "Notification": [
       {
         "matcher": "*",


### PR DESCRIPTION
## 変更内容

- `~/.claude/hooks/block-push-to-main.sh` を新規追加
- `~/.claude/settings.json` に PreToolUse フックを追加

## 背景

otosagashi プロジェクトのプロジェクトレベルフックをユーザーレベルに昇格させ、全プロジェクトで main/master への直接 push を防止する。

## 動作

- `git push` 実行時にブランチが `main` または `master` の場合は deny
- バイパスするには `ALLOW_PUSH_TO_MAIN=1` 環境変数を設定して Claude を起動する