### PR TITLE
feat: Android SDK の PATH を .zshrc に追加

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -26,6 +26,8 @@ export PATH="$HOME/.rbenv/bin:$PATH"
 export PATH="$HOME/.rbenv/shims:$PATH"
 export PATH=$PATH:$(go env GOPATH)/bin
 export PATH="$HOME/.local/bin:$PATH"
+export ANDROID_HOME="$HOME/Library/Android/sdk"
+export PATH="$ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools:$PATH"
 
 # -------------------
 # Homebrew and Completions


### PR DESCRIPTION
## 変更内容

- `~/.zshrc` に `ANDROID_HOME` と Android SDK 関連の PATH を追加

## 追加した PATH

```zsh
export ANDROID_HOME="$HOME/Library/Android/sdk"
export PATH="$ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools:$PATH"
```

## 目的

`emulator -list-avds` などの Android SDK コマンドをターミナルから直接実行できるようにするため。