### PR TITLE
fix(hook): mainへのpushガードをupstream追跡先・引数も検査するよう強化

### DIFF
--- a/dot_claude/hooks/block-push-to-main.sh
+++ b/dot_claude/hooks/block-push-to-main.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# PreToolUse フック: 現在のブランチが main のときの git push を弾く。
+# PreToolUse フック: main/master への git push を弾く。
+# 現在のブランチ名だけでなく、コマンド引数・追跡先も検査する。
 set -euo pipefail
 
 input=$(cat)
@@ -14,9 +15,7 @@ if [ "${ALLOW_PUSH_TO_MAIN:-}" = "1" ]; then
   exit 0
 fi
 
-branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-
-if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+deny() {
   cat <<'JSON'
 {
   "hookSpecificOutput": {
@@ -26,4 +25,22 @@ if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
   }
 }
 JSON
+  exit 0
+}
+
+# 1. 現在のブランチが main/master
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+  deny
+fi
+
+# 2. コマンド引数に main/master が含まれる（例: git push origin main）
+if echo "$command" | grep -qE '(^|\s|:)(main|master)(\s|$)'; then
+  deny
+fi
+
+# 3. push.default=upstream などで追跡先が origin/main になっている
+upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || echo "")
+if [ "$upstream" = "origin/main" ] || [ "$upstream" = "origin/master" ]; then
+  deny
 fi


### PR DESCRIPTION
## Why

`push.default=upstream` 環境でブランチの追跡先が `origin/main` になっている場合、現在のブランチ名が `main` でなくても直接 `main` へpushされてしまっていた。hookが現在のブランチ名しか見ていなかったため素通りした。

## What

`block-push-to-main.sh` に以下の3段階チェックを追加:

1. 現在のブランチ名が `main` / `master`（従来通り）
2. pushコマンドの引数に `main` / `master` が含まれる（例: `git push origin main`）
3. `push.default=upstream` などで追跡先が `origin/main` / `origin/master` になっている