### PR TITLE
fix(hooks): block-push-to-main フックの if 条件を削除

### DIFF
--- a/dot_claude/hooks/block-push-to-main.sh
+++ b/dot_claude/hooks/block-push-to-main.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# PreToolUse フック: 現在のブランチが main のときの git push を弾く。
+# PreToolUse フック: main/master への git push を弾く。
+# 現在のブランチ名だけでなく、コマンド引数・追跡先も検査する。
 set -euo pipefail
 
 input=$(cat)
@@ -14,9 +15,7 @@ if [ "${ALLOW_PUSH_TO_MAIN:-}" = "1" ]; then
   exit 0
 fi
 
-branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
-
-if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+deny() {
   cat <<'JSON'
 {
   "hookSpecificOutput": {
@@ -26,4 +25,22 @@ if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
   }
 }
 JSON
+  exit 0
+}
+
+# 1. 現在のブランチが main/master
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+  deny
+fi
+
+# 2. コマンド引数に main/master が含まれる（例: git push origin main）
+if echo "$command" | grep -qE '(^|\s|:)(main|master)(\s|$)'; then
+  deny
+fi
+
+# 3. push.default=upstream などで追跡先が origin/main になっている
+upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || echo "")
+if [ "$upstream" = "origin/main" ] || [ "$upstream" = "origin/master" ]; then
+  deny
 fi

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -135,7 +135,6 @@
         "hooks": [
           {
             "type": "command",
-            "if": "Bash(git push:*)",
             "command": "~/.claude/hooks/block-push-to-main.sh"
           }
         ]


### PR DESCRIPTION
## 問題

`block-push-to-main.sh` フックに `if: "Bash(git push:*)"` 条件が設定されていたが、  
これは Bash コマンド文字列が `git push` で**始まる**場合しかマッチしない。

Claude が複合コマンド（例: `git add -A && git commit -m "..." && git push`）で push した際、  
コマンド文字列の先頭が `git add` になるためフックがスキップされ、main への直接 push が通ってしまっていた。

## 修正

`if` 条件を削除し、すべての Bash ツール呼び出しでフックを起動させる。  
フックスクリプト側の `grep -qE 'git push'` は複合コマンドの中間に `git push` があっても正しく検出できるため、実質的な保護は変わらない。

## 確認方法

Claude Code セッションで `git push` を含む複合コマンドを実行し、フックに弾かれることを確認。