### PR TITLE
feat(security): gitleaks による pre-commit 秘匿情報チェックを追加

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -19,6 +19,7 @@ packages:
       - 'mcp-proxy'
       - 'codex'
       - 'googleworkspace-cli'
+      - 'gitleaks'
     casks:
       - 'cursor'
       - 'deepl'

--- a/.chezmoiscripts/run_once_after_configure-git-hooks.sh.tmpl
+++ b/.chezmoiscripts/run_once_after_configure-git-hooks.sh.tmpl
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# このリポジトリ (chezmoi source repo) 自体の git フックとして .githooks を使うよう設定する。
+# gitleaks による pre-commit の秘匿情報チェックを有効化するため。
+set -euo pipefail
+
+SRC_DIR="$(chezmoi source-path)"
+
+if [ -d "${SRC_DIR}/.git" ]; then
+  git -C "${SRC_DIR}" config core.hooksPath .githooks
+  echo "[git-hooks] core.hooksPath を .githooks に設定しました。"
+fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# gitleaks でステージ済みの変更に秘匿情報が含まれていないかチェックする pre-commit フック。
+# core.hooksPath=.githooks が設定されていると git commit 時に自動実行される。
+set -euo pipefail
+
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo "[pre-commit] gitleaks が見つかりません。'brew bundle' などでインストールしてください。" >&2
+  exit 1
+fi
+
+gitleaks protect --staged --redact -v --no-banner

--- a/README.md
+++ b/README.md
@@ -14,3 +14,13 @@ brew install chezmoi
 chezmoi init https://github.com/ko-tominaga/dotfiles.git
 chezmoi apply
 ```
+
+## Development
+
+このリポジトリ自身の変更をコミットする際は、[gitleaks](https://github.com/gitleaks/gitleaks) による秘匿情報チェックが pre-commit フックとして実行されます。
+
+`chezmoi apply` を実行すると `.chezmoiscripts/run_once_after_configure-git-hooks.sh.tmpl` が `core.hooksPath` を `.githooks` に設定し、自動的に有効化されます。手動で設定する場合は以下を実行してください。
+
+```sh
+git config core.hooksPath .githooks
+```


### PR DESCRIPTION
## Why

このリポジトリ（chezmoi の dotfiles ソース）にうっかり秘匿情報（APIキー・トークンなど）をコミットしてしまうリスクを防ぎたい。追加の Python 依存（pre-commit フレームワーク）を増やさず、既に導入予定の gitleaks 単体で完結させる。

## What

- `.chezmoidata/packages.yaml`: brew パッケージに `gitleaks` を追加
- `.githooks/pre-commit`: `gitleaks protect --staged` でステージ済みの差分をスキャンする pre-commit フック
- `.chezmoiscripts/run_once_after_configure-git-hooks.sh.tmpl`: `chezmoi apply` 実行時に、このリポジトリの `core.hooksPath` を `.githooks` に自動設定
- `README.md`: セットアップ方法（自動設定される旨と、手動での `git config core.hooksPath .githooks`）を追記

### 動作確認

- 偽の AWS キーを含むファイルのコミットが `aws-access-token` ルールでブロックされることを確認
- 秘匿情報を含まない通常の差分は `no leaks found` で通過することを確認