### PR TITLE
clauded エイリアスを削除

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -6,7 +6,6 @@ alias ls="ls -lah"
 alias che="chezmoi"
 alias python="python3"
 alias gwr='git gtr'
-alias clauded='claude --dangerously-skip-permissions'
 alias eche='cursor "$(chezmoi source-path)"'
 
 # -------------------


### PR DESCRIPTION
## Why
Claude Code で plan mode を使うようになったため、`--dangerously-skip-permissions` 付きで起動する `clauded` エイリアスが不要になった。

## What
- `dot_zshrc` から `alias clauded='claude --dangerously-skip-permissions'` を削除
- `chezmoi apply` 済み（`~/.zshrc` にも反映済み）