### PR TITLE
Claude Code のデフォルトモデルを Sonnet に設定

### DIFF
--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "includeCoAuthoredBy": true,
+  "model": "sonnet",
   "permissions": {
     "allow": [
       "List(*)",


### PR DESCRIPTION
## Why
一時的に Fable などの上位モデルに切り替えた後、戻し忘れてそのまま使い続けてしまうことがある。起動時のデフォルトを Sonnet に固定しておけば、セッションごとにリセットされるので戻し忘れがなくなる。

## What
- `dot_claude/settings.json` に `"model": "sonnet"` を追加
- ローカルの `~/.claude/settings.json` に残っていた `claude-fable-5[1m]` の指定はこの apply で Sonnet に置き換え済み