### PR TITLE
ANTHROPIC_MODEL=sonnet を環境変数に設定

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -18,6 +18,13 @@ PROMPT="%F{green}%n%f %F{cyan}($(arch))%f:%F{blue}%~%f"$'\n'"%# "
 source $(brew --prefix)/opt/zsh-git-prompt/zshrc.sh
 
 # -------------------
+# Claude Code Settings
+# -------------------
+# /model で切り替えても settings.json に保存され次回起動時に残ってしまうため、
+# 環境変数でデフォルトを固定する。--model フラグはこれより優先される。
+export ANTHROPIC_MODEL=sonnet
+
+# -------------------
 # Path Settings
 # -------------------
 export PATH="/Applications/RubyMine.app/Contents/MacOS:$PATH"


### PR DESCRIPTION
## Why
Claude Code で `/model` で一時的に Fable などに切り替えると、その選択が `~/.claude/settings.json` の `model` キーに保存され、次回起動時にも戻し忘れたモデルのまま起動してしまう。

## What
- `dot_zshrc` に `export ANTHROPIC_MODEL=sonnet` を追加
- 優先順位は `--model` フラグ > `ANTHROPIC_MODEL` 環境変数 > settings.json の `model` キー のため、通常起動時は常に sonnet になり、明示的に `claude --model <model>` を指定したときだけ別モデルで起動できる
- `chezmoi apply` 済み