### PR TITLE
fix: git-hooks設定スクリプトのchezmoi自己デッドロックを解消

### DIFF
--- a/.chezmoiscripts/run_once_after_configure-git-hooks.sh.tmpl
+++ b/.chezmoiscripts/run_once_after_configure-git-hooks.sh.tmpl
@@ -3,7 +3,7 @@
 # gitleaks による pre-commit の秘匿情報チェックを有効化するため。
 set -euo pipefail
 
-SRC_DIR="$(chezmoi source-path)"
+SRC_DIR="${CHEZMOI_SOURCE_DIR}"
 
 if [ -d "${SRC_DIR}/.git" ]; then
   git -C "${SRC_DIR}" config core.hooksPath .githooks


### PR DESCRIPTION
## 概要

`.chezmoiscripts/run_once_after_configure-git-hooks.sh.tmpl` が原因で `chezmoi apply` / `chezmoi update` 実行時に以下のエラーが発生していた問題を修正します。

```
chezmoi: timeout obtaining persistent state lock, is another instance of chezmoi running?
chezmoi: .chezmoiscripts/configure-git-hooks.sh: exit status 1
```

## 原因

- `chezmoi apply`/`update` 実行中は永続ステート(`chezmoistate.boltdb`)に書き込みロックがかかる。
- このスクリプトは `SRC_DIR="$(chezmoi source-path)"` として `chezmoi` コマンドを子プロセスとして呼び出していた。
- 子プロセスの `chezmoi source-path` が同じロックを取得しようとして自己デッドロックし、タイムアウトしていた。

## 修正内容

- `$(chezmoi source-path)` の呼び出しをやめ、chezmoiがスクリプト実行時に自動で渡す環境変数 `$CHEZMOI_SOURCE_DIR` を参照するように変更。
- これによりスクリプト内から `chezmoi` コマンドを呼ばなくなり、ロック競合が解消される。

## 動作確認

- `chezmoi apply --force` を実行し、エラーなく `core.hooksPath` の設定が完了することを確認済み。