### PR TITLE
[codex] update agent config

### DIFF
--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "includeCoAuthoredBy": true,
-  "model": "sonnet",
   "permissions": {
     "allow": [
       "List(*)",
@@ -164,17 +163,17 @@
       }
     ]
   },
+  "statusLine": {
+    "type": "command",
+    "command": "bash ~/.claude/statusline-command.sh"
+  },
   "enabledPlugins": {
     "example-skills@anthropic-agent-skills": true,
     "context7@claude-plugins-official": true,
     "code-review@claude-plugins-official": true,
     "ruby-lsp@claude-plugins-official": true,
-    "wantedly-dev@wantedly-cc-plugins": true
+    "posthog@claude-plugins-official": true
   },
   "alwaysThinkingEnabled": true,
-  "skipDangerousModePermissionPrompt": true,
-  "statusLine": {
-    "type": "command",
-    "command": "bash ~/.claude/statusline-command.sh"
-  }
+  "skipDangerousModePermissionPrompt": true
 }

--- a/dot_codex/private_config.toml
+++ b/dot_codex/private_config.toml
@@ -1,31 +1,28 @@
-# Codex configuration file
-# See: https://github.com/openai/codex/blob/main/docs/config.md
+#:schema https://developers.openai.com/codex/config-schema.json
 
 # Approval policy: when to prompt for approval
 # Options: "untrusted", "on-failure", "on-request", "never"
-approval_policy = "never"
+approval_policy = "on-request"
 
 # Sandbox mode: controls what commands can access
 # Options: "read-only", "workspace-write", "danger-full-access"
-sandbox_mode = "danger-full-access"
+sandbox_mode = "workspace-write"
 
 notify = ["bash", "-lc", "afplay /System/Library/Sounds/Ping.aiff"]
-model = "gpt-5.4"
+model = "gpt-5.5"
+model_reasoning_effort = "medium"
 
 [sandbox_workspace_write]
 # Allow network access in workspace-write mode
 network_access = true
 
-[mcp_servers.github]
-url = "https://api.githubcopilot.com/mcp/"
-bearer_token_env_var = "GITHUB_TOKEN"
-
 [mcp_servers.context7]
 command = "npx"
 args = [
-  "--transport",
   "-y",
-  "@upstash/context7-mcp"
+  "@upstash/context7-mcp",
+  "--transport",
+  "stdio"
 ]
 
 [plugins."github@openai-curated"]
@@ -33,3 +30,9 @@ enabled = true
 
 [plugins."google-drive@openai-curated"]
 enabled = true
+
+[tui.model_availability_nux]
+"gpt-5.5" = 1
+
+[notice.model_migrations]
+"gpt-5.4" = "gpt-5.5"

--- a/dot_codex/rules/custom.rules
+++ b/dot_codex/rules/custom.rules
@@ -1,0 +1,20 @@
+# Prompt before running commands with the prefix `gh pr view` outside the sandbox.
+prefix_rule(
+    # The prefix to match.
+    pattern = ["gh", "pr", "view"],
+
+    # The action to take when Codex requests to run a matching command.
+    decision = "prompt",
+
+    # `match` and `not_match` are optional "inline unit tests" where you can
+    # provide examples of commands that should (or should not) match this rule.
+    match = [
+        "gh pr view 7888",
+        "gh pr view --repo openai/codex",
+        "gh pr view 7888 --json title,body,comments",
+    ],
+    not_match = [
+        # Does not match because the `pattern` must be an exact prefix.
+        "gh pr --repo openai/codex view 7888",
+    ],
+)


### PR DESCRIPTION
## What changed

- Update Codex config to use `on-request` approvals with `workspace-write` sandboxing.
- Switch Codex to `gpt-5.5` and add model migration metadata.
- Fix the Context7 MCP `npx` argument order and add a custom Codex rule for `gh pr view`.
- Update Claude Code settings, including enabled plugins and status line placement.

## Why

This keeps the local agent configuration aligned with the newer Codex setup and makes Context7 invocation explicit with stdio transport.

## Validation

- `git diff --cached --check`
- `ruby -rjson -e 'JSON.parse(File.read("dot_claude/settings.json")); puts "json ok"'`

Note: local commit creation was blocked by the sandbox because `.git` is read-only in this session, so the branch commit was created through the GitHub API from the staged file contents.