### PR TITLE
fzfのキーバインドを導入しCtrl+Rで履歴のファジー検索を有効にする

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -53,6 +53,13 @@ if type brew &>/dev/null; then
 fi
 
 # -------------------
+# fzf (Ctrl+R: history / Ctrl+T: files / Alt+C: cd)
+# -------------------
+if type fzf &>/dev/null; then
+  source <(fzf --zsh)
+fi
+
+# -------------------
 # checkout git branch
 # -------------------
 # 本体は ~/.local/bin/git-fbr に切り出してある。worktree への cd だけは
@@ -74,7 +81,7 @@ fi
 # bindkeys
 # -------------------
 zle -N bind_fbr fbr
-bindkey '^T' bind_fbr
+bindkey '^G' bind_fbr
 
 # -------------------
 # Git Prompt Function (for git status in prompt)


### PR DESCRIPTION
## Why

コマンド履歴のサジェストを改善したい。zsh-autosuggestionsは既に導入済みで入力中のインライン候補は出るが、過去のコマンドをその場で絞り込んで検索する手段がなかったため、fzfのCtrl+R(履歴検索)を有効化する。

## What

- `.zshrc`に `source <(fzf --zsh)` を追加し、fzfのCtrl+R(履歴)/Ctrl+T(ファイル)/Alt+C(cd)のウィジェットを有効化する
- 既存の`fbr`(git branchの切り替え)がCtrl+Tを使用しており、fzfのファイル検索と競合するため、`fbr`のバインドをCtrl+Gに変更する

### 動作確認

- 新しいzshシェルで `bindkey` を確認し、Ctrl+R→`fzf-history-widget`、Ctrl+T→`fzf-file-widget`、Ctrl+G→`bind_fbr`になっていることを確認済み