### PR TITLE
git-workflowスキルにPR本文の抽象度に関する指針を追記

### DIFF
--- a/dot_claude/skills/git-workflow/SKILL.md
+++ b/dot_claude/skills/git-workflow/SKILL.md
@@ -63,6 +63,10 @@ refactor(db): simplify query builder logic
    （具体的な変更内容）
    ```
 
+   - **Whatは抽象度を上げて書く** — 「何を・なぜ変更したか」を書けば十分。
+     変更したメソッド名の列挙、削除した行数、`describe`ブロック名などの
+     差分を見れば自明な情報は書かない。レビュアーの認知負荷を増やすだけなので避ける。
+
 2. **PRを作成する**
    ```bash
    gh pr create --title "<タイトル>" --body "$(cat <<'EOF'


### PR DESCRIPTION
## 変更内容

`.claude/skills/git-workflow/SKILL.md` のPR作成手順に、Whatセクションの書き方についての指針を追記した。

## 理由

PRのWhatセクションに変更したメソッド名の列挙や削除行数などの低レベルな詳細を書いてしまい、レビュアーから「差分を見れば自明なことなので認知負荷が増えるだけ」と指摘を受けた。今後同じPRを作らないよう、「何を・なぜ変更したか」を抽象度を上げて書くことをスキルに明記した。