### PR TITLE
fix(hooks): block-push-to-mainのupstream誤検知を修正

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -20,6 +20,7 @@ packages:
       - 'codex'
       - 'googleworkspace-cli'
       - 'gitleaks'
+      - 'bats-core'
     casks:
       - 'cursor'
       - 'deepl'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,3 +56,9 @@ jobs:
         run: |
           echo "Checking what would be changed..."
           chezmoi diff || true
+
+      - name: Install bats-core
+        run: brew install bats-core
+
+      - name: Run hook tests
+        run: bats tests/hooks/*.bats

--- a/dot_claude/hooks/executable_block-push-to-main.sh
+++ b/dot_claude/hooks/executable_block-push-to-main.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# PreToolUse フック: main/master への git push を弾く。
+# 現在のブランチ名だけでなく、コマンド引数・追跡先も検査する。
+set -euo pipefail
+
+input=$(cat)
+command=$(echo "$input" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('tool_input',{}).get('command',''))" 2>/dev/null || echo "")
+
+# git push 系コマンドでなければスキップ
+if ! echo "$command" | grep -qE 'git push'; then
+  exit 0
+fi
+
+if [ "${ALLOW_PUSH_TO_MAIN:-}" = "1" ]; then
+  exit 0
+fi
+
+deny() {
+  cat <<'JSON'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "main / master ブランチへの直接pushは禁止です。バイパスするには環境変数 ALLOW_PUSH_TO_MAIN=1 を設定してClaudeを起動してください。"
+  }
+}
+JSON
+  exit 0
+}
+
+# 1. 現在のブランチが main/master
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+  deny
+fi
+
+# 2. コマンド引数に main/master が含まれる（例: git push origin main）
+if echo "$command" | grep -qE '(^|\s|:)(main|master)(\s|$)'; then
+  deny
+fi
+
+# 3. push.default=upstream などで追跡先が origin/main になっている
+#    ただし、これは「明示的なref/ブランチ指定がない裸のpush」(push.defaultに委ねる場合)
+#    にのみ適用する。`git push origin foo:foo` のように明示的に非main/masterへ
+#    push先を指定している場合は誤検知になるため対象外にする
+#    （main/masterを明示指定した場合は check 2 で既に弾かれている）。
+#    例:
+#      `git push`                -> 明示refなし(危険なら検査対象)
+#      `git push origin`         -> 同上
+#      `git push -u origin foo`  -> foo が明示refなので対象外
+#      `git push origin foo:foo` -> 同上
+has_explicit_ref=$(echo "$command" | python3 -c "
+import re, shlex, sys
+
+command = sys.stdin.read()
+match = re.search(r'git\s+push(.*)', command)
+rest = match.group(1) if match else ''
+try:
+    tokens = shlex.split(rest)
+except ValueError:
+    tokens = rest.split()
+
+remote_seen = False
+for token in tokens:
+    if token.startswith('-'):
+        continue
+    if not remote_seen:
+        # 最初の非フラグトークンはリモート名とみなす
+        remote_seen = True
+        continue
+    # リモート名の次に非フラグトークンがあれば明示的なref/refspec指定とみなす
+    print('yes')
+    break
+" 2>/dev/null || echo "")
+
+if [ -z "$has_explicit_ref" ]; then
+  upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' 2>/dev/null || echo "")
+  if [ "$upstream" = "origin/main" ] || [ "$upstream" = "origin/master" ]; then
+    deny
+  fi
+fi

--- a/tests/hooks/block-push-to-main.bats
+++ b/tests/hooks/block-push-to-main.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+# dot_claude/hooks/executable_block-push-to-main.sh のテスト。
+#
+# フックはstdinでPreToolUseのJSONを受け取り、危険なpushを検知した場合のみ
+# permissionDecision: deny を含むJSONをstdoutに出力する(exit codeは常に0)。
+# そのため各テストは「出力にdenyが含まれるか」でBLOCKED/ALLOWEDを判定する。
+
+setup() {
+  HOOK_SCRIPT="$BATS_TEST_DIRNAME/../../dot_claude/hooks/executable_block-push-to-main.sh"
+  REPO_DIR="$BATS_TEST_TMPDIR/repo"
+  BARE_DIR="$BATS_TEST_TMPDIR/origin.git"
+
+  git init -q --bare "$BARE_DIR"
+
+  mkdir -p "$REPO_DIR"
+  cd "$REPO_DIR"
+  git init -q -b work
+  git config user.email "test@example.com"
+  git config user.name "Test"
+  git commit -q --allow-empty -m "init"
+  git remote add origin "$BARE_DIR"
+}
+
+# 現在のブランチをorigin/mainにpushし、ローカルのリモート追跡ブランチを
+# origin/<name>に設定した上で、作業ブランチのupstreamをそこに向ける。
+# (`git worktree add -b <branch> origin/main` 後の状態を再現する)
+track_upstream_to() {
+  local remote_branch="$1"
+  git push -q origin "work:$remote_branch"
+  git fetch -q origin
+  git branch -q --set-upstream-to="origin/$remote_branch" work
+}
+
+run_hook() {
+  local cmd="$1"
+  printf '{"tool_input":{"command":"%s"}}' "$cmd" | "$HOOK_SCRIPT"
+}
+
+assert_blocked() {
+  [[ "$output" == *'"permissionDecision": "deny"'* ]]
+}
+
+assert_allowed() {
+  [ -z "$output" ]
+}
+
+@test "non git-push commands are allowed without inspection" {
+  run run_hook "git status"
+  assert_allowed
+}
+
+@test "ALLOW_PUSH_TO_MAIN=1 bypasses even a push on main" {
+  git checkout -q -b main
+  ALLOW_PUSH_TO_MAIN=1 run run_hook "git push"
+  assert_allowed
+}
+
+@test "check1: current branch main blocks regardless of args" {
+  git checkout -q -b main
+  run run_hook "git push origin feature:feature"
+  assert_blocked
+}
+
+@test "check1: current branch master blocks regardless of args" {
+  git checkout -q -b master
+  run run_hook "git push origin feature:feature"
+  assert_blocked
+}
+
+@test "check2: git push origin main is blocked" {
+  run run_hook "git push origin main"
+  assert_blocked
+}
+
+@test "check2: git push origin master is blocked" {
+  run run_hook "git push origin master"
+  assert_blocked
+}
+
+@test "check3: bare git push with upstream=origin/main is blocked" {
+  track_upstream_to main
+  run run_hook "git push"
+  assert_blocked
+}
+
+@test "check3: git push origin with upstream=origin/main is blocked" {
+  track_upstream_to main
+  run run_hook "git push origin"
+  assert_blocked
+}
+
+@test "check3: bare git push with upstream=origin/master is blocked" {
+  track_upstream_to master
+  run run_hook "git push"
+  assert_blocked
+}
+
+@test "check3: explicit non-main refspec with upstream=origin/main is allowed (regression fix)" {
+  track_upstream_to main
+  run run_hook "git push origin feature:feature"
+  assert_allowed
+}
+
+@test "check3: -u with explicit non-main branch and upstream=origin/main is allowed" {
+  track_upstream_to main
+  run run_hook "git push -u origin feature"
+  assert_allowed
+}
+
+@test "check3: branch name containing 'main' without word boundary is allowed" {
+  track_upstream_to main
+  run run_hook "git push origin feature-main:feature-main"
+  assert_allowed
+}
+
+@test "no upstream tracking means check3 never fires" {
+  run run_hook "git push"
+  assert_allowed
+}


### PR DESCRIPTION
## Why

`~/.claude/hooks/block-push-to-main.sh`（Claude Codeのgit push保護フック）のチェック3が、実際のpushコマンドの引数を見ずに「現在のブランチのupstream追跡先がorigin/main/masterかどうか」だけで判定していたため、以下のケースで誤検知していた。

`git worktree add -b <branch> origin/main` のように `origin/main` から直接新しいブランチを作ると、gitは自動的にそのブランチのupstream追跡先を `origin/main` に設定する。この状態で `git push origin foo:foo` のように明示的に非main/masterブランチへpushしても、実際にはmainへは一切影響がないにもかかわらずブロックされてしまっていた。

実際にClaude Codeでの作業中にこの誤検知でブロックされたため修正する。あわせて、このフックファイルがこれまでchezmoi管理外だったため、dotfilesとして取り込む。

## What

- `dot_claude/hooks/executable_block-push-to-main.sh` を新規追加（`~/.claude/hooks/block-push-to-main.sh` を取り込み）
- チェック3を「明示的なブランチ/refspec指定がない裸のpush」（`git push` / `git push origin` など push.default に委ねる形）にのみ適用するよう限定
  - `git push origin foo:foo` や `git push -u origin foo` のように明示的に非main/masterを指定している場合は対象外にする
  - `git push origin main` のように main/master を明示指定した場合は、従来通りチェック2でブロックされ続ける（安全性は維持）

## 動作確認

一時的なテスト用git remote/ローカルリポジトリを作って、以下のケースをフックスクリプトに直接JSON入力を渡して検証した（`upstream = origin/main` の状態を再現した上で）。

| コマンド | 結果 | 期待通りか |
|---|---|---|
| `git push` | BLOCKED | ✅（危険なケースなので維持） |
| `git push origin` | BLOCKED | ✅（同上） |
| `git push origin feature:feature` | ALLOWED | ✅（今回の修正で誤検知が解消） |
| `git push -u origin feature` | ALLOWED | ✅ |
| `git push origin main` | BLOCKED | ✅（main明示指定は引き続きブロック） |
| `git push origin feature-main:feature-main`（ブランチ名にmainを含むが単語境界一致しない） | ALLOWED | ✅（誤爆しないことを確認） |

`chezmoi diff` で差分確認後、`chezmoi apply --force` で実ファイルへ反映済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWukgyBc1jCwbGfFmgZYie