### PR TITLE
feat(packages): direnvを追加、bats-coreの巻き添え削除を復旧

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -20,6 +20,8 @@ packages:
       - 'codex'
       - 'googleworkspace-cli'
       - 'gitleaks'
+      - 'bats-core'
+      - 'direnv'
     casks:
       - 'cursor'
       - 'deepl'


### PR DESCRIPTION
## 変更内容
- `.chezmoidata/packages.yaml` の `brews` に `direnv` を追加
- 同時に、PR #72 のrevert (996ad46) で巻き添え削除されていた `bats-core` を復旧

## 理由
- `.zshrc` の `eval "$(direnv hook zsh)"` がdirenv未インストールでターミナル起動のたびに `command not found: direnv` エラーを出していたため、Brewfile経由で確実にインストールされるようにした
- `bats-core` は `tests/hooks/*.bats` の自動テストに必要だが、無関係なPRのrevertで意図せず消えていたため復旧

## 動作確認
- `brew install direnv` を実行しインストール済み
- `chezmoi apply --force ~/.Brewfile` で `~/.Brewfile` に反映済み