### PR TITLE
Spotlightのデフォルトホットキーを無効化

### DIFF
--- a/.chezmoiscripts/run_once_after_darwin-disable-spotlight-hotkey.sh.tmpl
+++ b/.chezmoiscripts/run_once_after_darwin-disable-spotlight-hotkey.sh.tmpl
@@ -1,0 +1,25 @@
+{{- if eq .chezmoi.os "darwin" -}}
+#!/usr/bin/env bash
+# Spotlight のデフォルトホットキー (⌘Space / ⌘⌥Space) を無効化する。
+# Raycast のグローバルホットキーを ⌘Space に割り当てるための前準備。
+set -euo pipefail
+
+log() { printf '[spotlight-hotkey] %s\n' "$*"; }
+
+PLIST_PATH="${HOME}/Library/Preferences/com.apple.symbolichotkeys.plist"
+
+set_disabled() {
+  local key="$1"
+  /usr/libexec/PlistBuddy -c "Set :AppleSymbolicHotKeys:${key}:enabled false" "${PLIST_PATH}" 2>/dev/null \
+    || /usr/libexec/PlistBuddy -c "Add :AppleSymbolicHotKeys:${key}:enabled bool false" "${PLIST_PATH}"
+}
+
+log "Disabling Spotlight hotkeys (key 64: Show Spotlight search, key 65: Show Finder search window)..."
+set_disabled 64
+set_disabled 65
+
+killall cfprefsd >/dev/null 2>&1 || true
+killall SystemUIServer >/dev/null 2>&1 || true
+
+log "Done. ログアウト/ログインしないと反映されない場合があります。"
+{{- end -}}


### PR DESCRIPTION
## 概要
- Raycastのグローバルホットキーを ⌘Space に変更する前準備として、macOS Spotlightのデフォルトホットキー(⌘Space / ⌘⌥Space)を無効化するスクリプトを追加

## 変更内容
- `.chezmoiscripts/run_once_after_darwin-disable-spotlight-hotkey.sh.tmpl` を追加
  - `com.apple.symbolichotkeys.plist` の `AppleSymbolicHotKeys` キー64(Spotlight検索を表示)・65(Finder検索ウィンドウ)の `enabled` を `false` に設定
  - `cfprefsd` / `SystemUIServer` を再起動してキャッシュを反映

## 動作確認
- [x] `chezmoi apply --force` を実行し、スクリプトが正常終了することを確認
- [ ] ログアウト/ログイン後、⌘Spaceに反応しなくなることを確認
- [ ] Raycast側の設定で ⌘Space をグローバルホットキーとして設定