### PR TITLE
bat, git-deltaの追加とgitconfigのdelta設定を反映

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -22,6 +22,8 @@ packages:
       - 'gitleaks'
       - 'bats-core'
       - 'direnv'
+      - 'bat'
+      - 'git-delta'
     casks:
       - 'cursor'
       - 'deepl'

--- a/dot_gitconfig
+++ b/dot_gitconfig
@@ -11,3 +11,9 @@
 	postBuffer = 524288000
 [push]
 	default = upstream
+[core]
+	pager = delta
+[interactive]
+	diffFilter = delta --color-only
+[delta]
+	navigate = true


### PR DESCRIPTION
## Summary
- Homebrewパッケージに `bat`, `git-delta` を追加
- `~/.gitconfig` に手動で追加していたdelta連携設定(`core.pager`, `interactive.diffFilter`, `delta.navigate`)がchezmoiソースに未反映(ドリフト)だったため、`chezmoi add` で取り込み

## Test plan
- [ ] `chezmoi apply` 後、`brew list` に `bat` / `git-delta` が含まれることを確認
- [ ] `git diff` 実行時にdeltaの表示になることを確認