### PR TITLE
chezmoi update を明示的にmainブランチで実行するコマンドを追加

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -9,6 +9,16 @@ alias gwr='git gtr'
 alias eche='cursor "$(chezmoi source-path)"'
 
 # -------------------
+# chezmoi update (main専用)
+# -------------------
+# 通常の `chezmoi update` はchezmoiソースの現在のブランチのままupdateする
+# (作業ブランチでのテスト用にそのままにしておきたい)。
+# mainの最新dotfilesを明示的に取り込みたい時だけこちらを使う。
+chezmoi-update-main() {
+  chezmoi git -- checkout main && chezmoi update
+}
+
+# -------------------
 # Zsh Prompt Settings
 # -------------------
 autoload -Uz colors && colors


### PR DESCRIPTION
## Summary
- `chezmoi-update-main` 関数を `.zshrc` に追加
- 通常の `chezmoi update` は挙動を変えず、現在のブランチのままupdateする(作業ブランチでのテスト用途を維持)
- `chezmoi-update-main` を明示的に呼んだ時だけ `chezmoi git -- checkout main && chezmoi update` を実行し、mainの最新dotfilesを取り込む

## 背景
chezmoi sourceディレクトリが作業ブランチのままだと `chezmoi update` で意図した修正が当たらない問題があった。一方で作業ブランチでのテストのために特定ブランチでupdateを実行したいケースもあるため、自動でmainに切り替えるのではなく専用コマンドとして用意した。

## Test plan
- [ ] `source ~/.zshrc` 後、`chezmoi-update-main` が定義されていることを確認
- [ ] 作業ブランチにいる状態で `chezmoi-update-main` を実行し、sourceがmainに切り替わってupdateされることを確認
- [ ] 通常の `chezmoi update` は現在のブランチのままである挙動が変わっていないことを確認