### PR TITLE
Ghosttyのopt+spaceをQuick Terminalトグルに変更

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -1,4 +1,4 @@
-keybind = global:opt+space=new_window
+keybind = global:opt+space=toggle_quick_terminal
 background-opacity = 0.85
 background-blur-radius = 20
 cursor-style = block


### PR DESCRIPTION
## 変更内容
- `dot_config/ghostty/config` の `keybind = global:opt+space=new_window` を `keybind = global:opt+space=toggle_quick_terminal` に変更

## 理由
これまでは opt+space を押すたびに新規ウィンドウが起動していたが、iTerm2のホットキーウィンドウのように以下の挙動にしたい:
- Ghosttyが未起動なら起動する
- 起動済みならウィンドウをトグル(フォーカス/非表示)する

`toggle_quick_terminal` はGhostty組み込みのQuick Terminal機能で、この挙動を実現する。

## 動作確認方法
1. `chezmoi apply` 後、Ghosttyを完全終了する
2. opt+space を押して Ghostty が起動しフォーカスされることを確認
3. 再度 opt+space を押してウィンドウが隠れることを確認
4. 3度目の opt+space で再度フォーカスされることを確認

※ 初回はmacOSのアクセシビリティ権限の許可ダイアログが出る場合がある