### PR TITLE
tmuxのコピーモードをvim風にし、ghosttyの設定を調整

### DIFF
--- a/dot_config/ghostty/config
+++ b/dot_config/ghostty/config
@@ -3,3 +3,5 @@ background-opacity = 0.85
 background-blur-radius = 20
 cursor-style = block
 cursor-style-blink = true
+quick-terminal-size = 50%
+font-size = 16

--- a/dot_tmux.conf
+++ b/dot_tmux.conf
@@ -1,0 +1,6 @@
+set -g mode-keys vi
+set -g mouse on
+
+bind-key -T copy-mode-vi v send-keys -X begin-selection
+bind-key -T copy-mode-vi C-v send-keys -X rectangle-toggle
+bind-key -T copy-mode-vi y send-keys -X copy-selection-and-cancel


### PR DESCRIPTION
## 変更内容

### tmux (`dot_tmux.conf`)
`mode-keys vi` にしていても、コピーモードの `v` はデフォルトで `rectangle-toggle`、`y` は未バインドのままで、vimのように「vで選択開始 → yでコピー」という操作ができなかった。以下を明示的に追加:

```
bind-key -T copy-mode-vi v send-keys -X begin-selection
bind-key -T copy-mode-vi C-v send-keys -X rectangle-toggle
bind-key -T copy-mode-vi y send-keys -X copy-selection-and-cancel
```

矩形選択は `Ctrl-v` に退避。

### ghostty (`dot_config/ghostty/config`)
`quick-terminal-size = 50%` と `font-size = 16` を追加(既存の変更)。

## 動作確認方法
- `tmux` を起動し、コピーモードで `v` → カーソル移動 → `y` でコピーできることを確認